### PR TITLE
add failing whitespace test

### DIFF
--- a/test.js
+++ b/test.js
@@ -11,6 +11,18 @@ if (!module.parent) {
 }
 
 function specificTests (morph) {
+  tape('integration', function (t) {
+    var a = html`<ul>
+</ul>`
+    var b = html`<ul><li></li><li></li>
+</ul>`
+    console.log('a', a.outerHTML)
+    console.log('b', b.outerHTML)
+    compare(a, b, t)
+    console.log('morphed', a.outerHTML)
+    t.end()
+  })
+
   tape('nanomorph', function (t) {
     t.test('should assert input types', function (t) {
       t.plan(2)


### PR DESCRIPTION
```
a:

<ul>
</ul>

b:

<ul><li></li><li></li>
</ul>

morphed:

<ul><li></li>
</ul>
```

This is the most minimal failing test for this I could create, removing a single more element _or_ newline would make it pass.