### PR TITLE
Use data-diffKey to pass list update hints

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,5 +145,10 @@ function same (a, b) {
   if (a.isSameNode) return a.isSameNode(b)
   if (a.tagName !== b.tagName) return false
   if (a.type === TEXT_NODE) return a.nodeValue === b.nodeValue
+  if (
+    a.dataset.diffkey &&
+    b.dataset.diffkey &&
+    a.dataset.diffkey === b.dataset.key
+  ) return true
   return false
 }


### PR DESCRIPTION
This tiny PR adds a single `if` statement to the `same(a, b)` function used to find good list-reorder candidates in lists of elements.  The new check identifies matches when `a.dataset.diffkey === b.dataset.diffkey`.

This has the effect of decoupling diff-hint keys from `id` values.  A couple nice benefits:

1.  No pressure to make diff-hint keys globally unique.  For diff optimization, the only constraint is that diff-hint keys should be unique _within the element list_.

2.  No risk of collision with other users of the `id` namespace, like `<a href="#x">jump</a>` targets.

I'm not particularly attached to `data-diffkey` as the attribute name, but it's short, self-documenting, and easy to access with `element.dataset.diffkey`.

Big thanks to @juliangruber for the recent refactor.  Very clear.