### PR TITLE
oncreate/onremove lifecycle events

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,19 +89,23 @@ function updateChildren (newNode, oldNode) {
 
     // There is no new child, remove old
     } else if (!newChild) {
+      unmount(oldChild)
       oldNode.removeChild(oldChild)
       i--
 
     // There is no old child, add new
     } else if (!oldChild) {
       oldNode.appendChild(newChild)
+      mount(newChild)
       offset++
 
     // Both nodes are the same, morph
     } else if (same(newChild, oldChild)) {
       morphed = walk(newChild, oldChild)
       if (morphed !== oldChild) {
+        unmount(oldChild)
         oldNode.replaceChild(morphed, oldChild)
+        mount(morphed)
         offset++
       }
 
@@ -127,13 +131,16 @@ function updateChildren (newNode, oldNode) {
       } else if (!newChild.id && !oldChild.id) {
         morphed = walk(newChild, oldChild)
         if (morphed !== oldChild) {
+          unmount(oldChild)
           oldNode.replaceChild(morphed, oldChild)
+          mount(morphed)
           offset++
         }
 
       // Insert the node at the index if we couldn't morph or find a matching node
       } else {
         oldNode.insertBefore(newChild, oldChild)
+        mount(newChild)
         offset++
       }
     }
@@ -146,4 +153,19 @@ function same (a, b) {
   if (a.tagName !== b.tagName) return false
   if (a.type === TEXT_NODE) return a.nodeValue === b.nodeValue
   return false
+}
+
+function mount (node) {
+  var children = node.childNodes
+  for (var i = 0; i < children.length; i++) {
+    mount(children[i])
+  }
+  if (node.oncreate) node.oncreate(node)
+}
+function unmount (node) {
+  var children = node.childNodes
+  for (var i = 0; i < children.length; i++) {
+    unmount(children[i])
+  }
+  if (node.onremove) node.onremove(node)
 }

--- a/test/diff.js
+++ b/test/diff.js
@@ -294,6 +294,74 @@ function abstractMorph (morph) {
       a = morph(a, b)
       t.equal(a.outerHTML, expected, 'result was expected')
     })
+
+    t.test('lifecycle callbacks', function (t) {
+      t.test('should call oncreate when element is appended', function (t) {
+        t.plan(5)
+        var calledParent = 0
+        var calledChild = 0
+        // eslint-disable-next-line no-unused-vars
+        var a = html`
+          <body></body>
+        `
+        var b = html`
+          <body>
+            <div oncreate=${oncreateParent}></div>
+          </body>
+        `
+
+        a = morph(a, b)
+        t.equal(calledParent, 1, 'should have called oncreate on new element')
+
+        b = html`
+          <body>
+            <div oncreate=${oncreateParent}>
+              <div oncreate=${oncreateChild} />
+            </div>
+          </body>
+        `
+        a = morph(a, b)
+        t.equal(calledParent, 1, 'should not have called oncreate on existing element')
+        t.equal(calledChild, 1, 'should have called oncreate on new child')
+        a = morph(a, b)
+        t.equal(calledParent, 1, 'should not have called oncreate on existing element')
+        t.equal(calledChild, 1, 'should not have called oncreate on existing child')
+        function oncreateParent () {
+          calledParent++
+        }
+        function oncreateChild () {
+          calledChild++
+        }
+      })
+
+      t.test('should call onremove when element is removed', function (t) {
+        t.plan(5)
+        var parentRemoved = false
+        var childRemoved = false
+        function onremoveParent () {
+          t.pass('should call onremove on removed nodes')
+          t.equal(childRemoved, true, 'should call onremove on parent nodes after calling it on child nodes')
+          parentRemoved = true
+        }
+        function onremoveChild () {
+          t.pass('should call onremove on removed nodes')
+          t.equal(parentRemoved, false, 'should call onremove on child nodes before calling it on parent nodes')
+          childRemoved = true
+        }
+
+        var a = html`
+          <div>
+            <h1 onremove=${onremoveParent}>
+              <span onremove=${onremoveChild}></span>
+            </h1>
+          </div>
+        `
+
+        morph(a, html`<div></div>`)
+
+        t.equal(parentRemoved, true, 'should have called onremove on everything')
+      })
+    })
   })
 }
 


### PR DESCRIPTION
This is just an idea i was trying out, submitting now in this early stage to see if people would even like something like this to be in nanomorph or not :D opinions & feedback very much appreciated ✨ 

This patch adds an `oncreate` event that's called when a node is first appended, and an `onremove` event that's called when a node is removed. It's used like:

```js
var html = require('bel')
var morph = require('nanomorph')
var app = html`<div id="app"></div>`
var map

morph(app, html`
  <div id="app">
    <div oncreate=${makeLeaflet} onremove=${destroyLeaflet}></div>
    <canvas oncreate=${makeArt} width="600" height="400"></canvas>
  </div>
`)

function makeArt (el) {
  // make some art
}
function makeLeaflet (el) {
  // draw a map
  map = L.map(el).setView([51.505, -0.09], 13)
  L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
      attribution: '&copy; <a href="http://osm.org/copyright">OpenStreetMap</a> contributors'
  }).addTo(map)
}
function destroyLeaflet (el) {
  map.remove()
  map = null
}
```

This imo is a simpler approach to lifecycles than provided by `on-load`, although it's also subtly different: `oncreate` doesn't guarantee the element is mounted anywhere in "The" DOM (`document.body` and children), just that it was added to any old DOM tree. `onremove` is called before the element is actually removed, while `unload` is called after an element was removed(?), I'm not sure if this is the best approach.

both lifecycle events are called in 'bottom-up' order, so child nodes' events are called before their parents' events. this made sense to me, if a child node uses `oncreate` to for example render a twitter widget into itself, when the parent's `oncreate` is called the twitter widget is already there, i.e. the child node is 'done'. I think `componentDidMount` in react flavors works the same way.
for `onremove` i think it makes most intuitive sense to 'deinitialise' child nodes first, but I don't know if there's a use case there where the order would matter.

---

It needs some more work, like the one big caveat right now is that lifecycle events on top-level nodes don't work, since you're always morphing an existing element and this patch doesn't think about that:

```js
morph(document.body, html`
  <body oncreate=${onbodycreated}>
    <h1>hello world</h1>
  </body>
`)
```

that never calls `onbodycreated` because the body element already existed. same with using this from inside nanocomponent, atm, since it first calls `createElement()` and it only morphs on the next calls. I haven't thought of non-hacky ways to fix that so far. in nanocomponent you could `morph()` from a `null` node on the first render call if we implement a special case for that in nanomorph, but even that wouldn't work when morphing onto an existing dom tree, whether a server side rendered one or the initial `<body>` element in a choo app.