### PR TITLE
Add support for `data-same-node` attribute

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,6 +49,8 @@ function walk (newNode, oldNode) {
     return null
   } else if (newNode.isSameNode && newNode.isSameNode(oldNode)) {
     return oldNode
+  } else if (newNode.dataset && newNode.dataset.sameNode && newNode.dataset.sameNode.toLowerCase() === 'true') {
+    return oldNode
   } else if (newNode.tagName !== oldNode.tagName) {
     return newNode
   } else {

--- a/test/diff.js
+++ b/test/diff.js
@@ -157,6 +157,32 @@ function abstractMorph (morph) {
       })
     })
 
+    t.test('data-same-node', function (t) {
+      t.test('should return a if true', function (t) {
+        t.plan(1)
+        var a = html`<div>YOLO</div>`
+        var b = html`<div data-same-node="true">FOMO</div>`
+        var res = morph(a, b)
+        t.equal(res.childNodes[0].data, 'YOLO')
+      })
+
+      t.test('should return a if TRUE', function (t) {
+        t.plan(1)
+        var a = html`<div>YOLO</div>`
+        var b = html`<div data-same-node="TRUE">FOMO</div>`
+        var res = morph(a, b)
+        t.equal(res.childNodes[0].data, 'YOLO')
+      })
+
+      t.test('should return b if false', function (t) {
+        t.plan(1)
+        var a = html`<div>YOLO</div>`
+        var b = html`<div data-same-node="false">FOMO</div>`
+        var res = morph(a, b)
+        t.equal(res.childNodes[0].data, 'FOMO')
+      })
+    })
+
     t.test('lists', function (t) {
       t.test('should append nodes', function (t) {
         t.plan(1)


### PR DESCRIPTION
This PR makes it possible to control `isSameNode` behaviour through a `data-same-node` attribute in the element markup. I think this results in a slightly more idiomatic syntax when using this in `choo`, for example:

```js
function view (state, emit) {
    return html`<nav data-same-node=${changeNav(state.navigation)}>
        <ul>${state.navigation.current.map(navItem)}</ul>
    </nav>`
}

function changeNav (navigation) {
    return navigation.current.length !== navigation.prev.length
}
```

If you're interested in merging this, I'll add some documentation to the "Caching DOM elements" section.