### PR TITLE
Document Fragments

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,12 @@ function nanomorph (oldTree, newTree) {
   // }
   assert.equal(typeof oldTree, 'object', 'nanomorph: oldTree should be an object')
   assert.equal(typeof newTree, 'object', 'nanomorph: newTree should be an object')
+  assert.notEqual(
+    newTree.nodeType,
+    11,
+    'nanomorph: newTree should have one root node (which is not a DocumentFragment)'
+  )
+
   var tree = walk(newTree, oldTree)
   // if (DEBUG) console.log('=> morphed\n  %s', tree.outerHTML)
   return tree

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "browserify": "^14.1.0",
     "dependency-check": "^2.5.1",
     "math-random-seed": "^1.0.0",
-    "nanohtml": "^1.2.4",
+    "nanohtml": "^1.4.0",
     "standard": "^10.0.3",
     "tape": "^4.6.0",
     "tape-run": "^3.0.0"

--- a/test/diff.js
+++ b/test/diff.js
@@ -440,3 +440,11 @@ tape('use id as a key hint', function (t) {
     t.end()
   })
 })
+
+tape('disallow document fragments', function (t) {
+  var a = html`<div><div>a</div></div>`
+  var b = html`<div>a</div><div>b</div>`
+
+  t.throws(nanomorph.bind(null, a, b), /newTree should have one root node/, 'no fragments')
+  t.end()
+})


### PR DESCRIPTION
If we allow DocumentFragments to be generated with nanohtml (https://github.com/choojs/nanohtml/pull/118), then we should make sure that they can't be used to morph the existing tree.

Morphing with a DocumentFragment doesn't make sense, because it doesn't have an actual root node.

Potentially we could also define that if a DocumentFragment is used it will only morph the children of the rootTree. That would also solve https://github.com/choojs/nanomorph/issues/96. But I think that should be discussed further somewhere.

For now this is my proposal: I added an assert statement, so it will reject DocumentFragments. 