### PR TITLE
Added exports#default

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ var morph = require('./lib/morph')
 var TEXT_NODE = 3
 // var DEBUG = false
 
-module.exports = nanomorph
+(module.exports = nanomorph).default = nanomorph;
 
 // Morph one tree into another tree
 //


### PR DESCRIPTION
AAdded exports#default, which adds support for things like "rollup-plugin-commonjs" which transpile commonJS modules into ES6 modules before transpilation, and other bundlers which do the same thing. It adds support for es6 modules, and it's only 7 letters, so it's worth it in the long run.