### PR TITLE
Changed assert require calls to nanoassert

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-var assert = require('assert')
+var assert = require('nanoassert')
 var morph = require('./lib/morph')
 
 var TEXT_NODE = 3


### PR DESCRIPTION
This **really** is a big difference to me, because "assert" requires "buffer", meaning a buffer polyfill is included in builds including nanomorph. This saves 2000 lines of code in Rollup builds.