### PR TITLE
Allow new tree to be DocumentFragment if `childrenOnly`

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,16 +29,17 @@ function nanomorph (oldTree, newTree, options) {
   // }
   assert.equal(typeof oldTree, 'object', 'nanomorph: oldTree should be an object')
   assert.equal(typeof newTree, 'object', 'nanomorph: newTree should be an object')
-  assert.notEqual(
-    newTree.nodeType,
-    11,
-    'nanomorph: newTree should have one root node (which is not a DocumentFragment)'
-  )
 
   if (options && options.childrenOnly) {
     updateChildren(newTree, oldTree)
     return oldTree
   }
+
+  assert.notEqual(
+    newTree.nodeType,
+    11,
+    'nanomorph: newTree should have one root node (which is not a DocumentFragment)'
+  )
 
   return walk(newTree, oldTree)
 }

--- a/test/diff.js
+++ b/test/diff.js
@@ -476,11 +476,11 @@ tape('fragments', function (t) {
   })
 
   t.test('allow document fragments with `childrenOnly`', function (t) {
-    var a = html`<div><div>a</div></div>`
+    var a = html`<main><div>a</div></main>`
     var b = html`<div>a</div><div>b</div>`
 
     var c = nanomorph(a, b, { childrenOnly: true })
-    t.equals(c.outerHTML, '<div><div>a</div><div>b</div></div>')
+    t.equals(c.outerHTML, '<main><div>a</div><div>b</div></main>')
     t.end()
   })
 

--- a/test/diff.js
+++ b/test/diff.js
@@ -466,10 +466,23 @@ tape('use id as a key hint', function (t) {
   t.end()
 })
 
-tape('disallow document fragments', function (t) {
-  var a = html`<div><div>a</div></div>`
-  var b = html`<div>a</div><div>b</div>`
+tape('fragments', function (t) {
+  t.test('disallow document fragments', function (t) {
+    var a = html`<div><div>a</div></div>`
+    var b = html`<div>a</div><div>b</div>`
 
-  t.throws(nanomorph.bind(null, a, b), /newTree should have one root node/, 'no fragments')
+    t.throws(nanomorph.bind(null, a, b), /newTree should have one root node/, 'no fragments')
+    t.end()
+  })
+
+  t.test('allow document fragments with `childrenOnly`', function (t) {
+    var a = html`<div><div>a</div></div>`
+    var b = html`<div>a</div><div>b</div>`
+
+    var c = nanomorph(a, b, { childrenOnly: true })
+    t.equals(c.outerHTML, '<div><div>a</div><div>b</div></div>')
+    t.end()
+  })
+
   t.end()
 })


### PR DESCRIPTION
Previously you could do
```js
var children = [...]
var newCh = [...]
morph(html`<div>${children}</div>`, html`<section>${newCh}</section>`, { childrenOnly: true })
```
and the root `<div>` tag would be untouched, only the `children` arrays would be morphed.

With this PR, you can do the same for fragments
```js
var children = [...]
var newCh = [...]
var frag = document.createDocumentFragment()
frag.append(...newCh)
morph(html`<div>${children}</div>`, frag, { childrenOnly: true })
```