### PR TITLE
Indeterminate checkbox property

### DIFF
--- a/lib/morph.js
+++ b/lib/morph.js
@@ -117,6 +117,12 @@ function updateInput (newNode, oldNode) {
   updateAttribute(newNode, oldNode, 'checked')
   updateAttribute(newNode, oldNode, 'disabled')
 
+  // The "indeterminate" property can not be set using an HTML attribute.
+  // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox
+  if (newNode.indeterminate !== oldNode.indeterminate) {
+    oldNode.indeterminate = newNode.indeterminate
+  }
+
   if (newValue !== oldValue) {
     oldNode.setAttribute('value', newValue)
     oldNode.value = newValue

--- a/test/diff.js
+++ b/test/diff.js
@@ -168,6 +168,67 @@ function abstractMorph (morph) {
       t.end()
     })
 
+    function booleanPropertyTest (property) {
+      return function (t) {
+        t.test(`if new tree has no ${property} and old tree does, remove value`, function (t) {
+          t.plan(1)
+          var a = html`<input type="checkbox" ${property}=${true} />`
+          var b = html`<input type="checkbox" />`
+          var res = morph(a, b)
+          t.equal(res[property], false)
+        })
+
+        t.test(`if new tree has ${property} and old tree does not, add value`, function (t) {
+          t.plan(1)
+          var a = html`<input type="checkbox" />`
+          var b = html`<input type="checkbox" ${property}=${true} />`
+          var res = morph(a, b)
+          t.equal(res[property], true)
+        })
+
+        t.test(`if new tree has ${property} and old tree does too, set value from new tree`, function (t) {
+          t.plan(6)
+          var a = html`<input type="checkbox" ${property}=${false} />`
+          var b = html`<input type="checkbox" ${property}=${true} />`
+          var res = morph(a, b)
+          t.equal(res[property], true)
+
+          a = html`<input type="checkbox" ${property}=${true} />`
+          b = html`<input type="checkbox" ${property}=${false} />`
+          res = morph(a, b)
+          t.equal(res[property], false)
+
+          a = html`<input type="checkbox"/>`
+          b = html`<input type="checkbox"/>`
+          b[property] = true
+          res = morph(a, b)
+          t.equal(res[property], true)
+
+          a = html`<input type="checkbox" ${property}=${false}/>`
+          b = html`<input type="checkbox"/>`
+          b[property] = true
+          res = morph(a, b)
+          t.equal(res[property], true)
+
+          a = html`<input type="checkbox" ${property}=${true}/>`
+          b = html`<input type="checkbox"/>`
+          b[property] = false
+          res = morph(a, b)
+          t.equal(res[property], false)
+
+          a = html`<input type="checkbox"/>`
+          b = html`<input type="checkbox" ${property}=${true}/>`
+          res = morph(a, b)
+          t.equal(res[property], true)
+        })
+
+        t.end()
+      }
+    }
+
+    t.test('checked', booleanPropertyTest('checked'))
+    t.test('disabled', booleanPropertyTest('disabled'))
+
     t.test('isSameNode', function (t) {
       t.test('should return a if true', function (t) {
         t.plan(1)

--- a/test/diff.js
+++ b/test/diff.js
@@ -229,6 +229,21 @@ function abstractMorph (morph) {
     t.test('checked', booleanPropertyTest('checked'))
     t.test('disabled', booleanPropertyTest('disabled'))
 
+    t.test('indeterminate', function (t) {
+      t.plan(2)
+      var a = html`<input type="checkbox"/>`
+      var b = html`<input type="checkbox"/>`
+      b.indeterminate = true
+      var res = morph(a, b)
+      t.equal(res.indeterminate, true)
+
+      a = html`<input type="checkbox"/>`
+      b = html`<input type="checkbox"/>`
+      a.indeterminate = true
+      res = morph(a, b)
+      t.equal(res.indeterminate, false)
+    })
+
     t.test('isSameNode', function (t) {
       t.test('should return a if true', function (t) {
         t.plan(1)


### PR DESCRIPTION
The HTML living standard defines the `indeterminate` property for checkboxes. It cannot be set using an HTML attribute though, only through JavaScript. Currently, the choo DOM diffing does not respect this property.

I have added test cases for the `checkbox` and `disabled` properties as a separate commit, since I expected them to behave similar to `indeterminate`. However, attempting to allow setting the property like `<input type="checkbox" indeterminate=${false}>` does not do the expected thing and would still set the property to `true`.

Refs:

- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/checkbox
- https://css-tricks.com/indeterminate-checkboxes/