### PR TITLE
Fix file input losing its value on morph

### DIFF
--- a/lib/morph.js
+++ b/lib/morph.js
@@ -123,6 +123,9 @@ function updateInput (newNode, oldNode) {
     oldNode.indeterminate = newNode.indeterminate
   }
 
+  // Persist file value since file inputs can't be changed programatically
+  if (oldNode.type === 'file') return
+
   if (newValue !== oldValue) {
     oldNode.setAttribute('value', newValue)
     oldNode.value = newValue


### PR DESCRIPTION
An input of type `file` can't have its value set programmatically. This fix simply preserves whatever value is set to an input with `type="file"`.