### PR TITLE
Fix morph from text node to comment node

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ function walk (newNode, oldNode) {
     return null
   } else if (newNode.isSameNode && newNode.isSameNode(oldNode)) {
     return oldNode
-  } else if (newNode.tagName !== oldNode.tagName || getComponentId(newNode) !== getComponentId(oldNode)) {
+  } else if (newNode.nodeName !== oldNode.nodeName || getComponentId(newNode) !== getComponentId(oldNode)) {
     return newNode
   } else {
     morph(newNode, oldNode)


### PR DESCRIPTION
I'm not entirely sure what all the ramifications of this change are, but they fix a bug I was running into with HTML comments.

The bug was that occasionally my comment text would wind up getting rendered as DOM text after a morph. Sometimes during a `walk` morph would try to morph a text node into a comment node, which was no good.

I **think** my change prevents morph from ever trying to go from text node to comment node. `tagName` is `undefined` for both text and comment nodes, but `nodeName` is meaningful. And I **think** `nodeName` has the same value as `tagName` in most other cases, but I'm not too sure about this. See: https://developer.mozilla.org/en-US/docs/Web/API/Node/nodeName.

Here's some code that repro's the bug. When you click, you'll see the number 1 show up in the DOM, even though it's supposed to be in a comment.

test.html
```html
<div id="test"></div>

<script type="module">

  import morph from './nanomorph.es6.js'
  import html from './nanohtml.es6.js'

  let parent = document.querySelector('#test')

  let fragment = () => html`
    <!-- 1 -->
    <!-- 2 -->
  `

  morph(parent, html`
    <div id="test">
      ${ fragment() }
    </div>
  `)

  document.addEventListener('click', () => {
    morph(parent, html`
      <div id="test">
        <div>Hello</div>
        ${ fragment() }
      </div>
    `)
  })

</script>
```